### PR TITLE
Update message.go

### DIFF
--- a/consumer/message.go
+++ b/consumer/message.go
@@ -1,10 +1,10 @@
 package consumer
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/nsqio/go-nsq"
-	"golang.org/x/net/context"
 )
 
 // Message - Inherent nsq


### PR DESCRIPTION
Removed "golang.org/x/net/context" in favor of context package in Go 1.7+